### PR TITLE
Update import path for piotrnar/gocoin.

### DIFF
--- a/bip38/decrypt.go
+++ b/bip38/decrypt.go
@@ -6,7 +6,7 @@ import (
 	"crypto/aes"
 	"crypto/sha256"
 	"encoding/hex"
-	"github.com/piotrnar/gocoin/btc"
+	"github.com/piotrnar/gocoin/lib/btc"
 	"log"
 	"math/big"
 )


### PR DESCRIPTION
`go get` step fails, since `gocoin` has changed paths for release 1.0.0.

In addition to this, `btc.PublicFromPrivate()` no longer returns an error, so calls in `decrypt.go` fail. I suggest checks be changed to something like [this](https://github.com/piotrnar/gocoin/blob/d707f0be87148ed5b4b73a5bbf9518d7c3d389a3/wallet/stealth.go#L38), or the issue be brought up upstream.
